### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "dotenv": "^16.5.0",
     "lowdb": "^7.0.1",
     "multer": "^2.0.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.3",

--- a/src/utils/downloadHandler.ts
+++ b/src/utils/downloadHandler.ts
@@ -2,10 +2,17 @@ import express, { Request, Response, NextFunction } from 'express';
 import path from 'path';
 import { sfxDB } from '../db';
 import { asyncHandler } from './asyncHandler';
+import rateLimit from 'express-rate-limit';
 
 const soundsRouter = express.Router();
 
-soundsRouter.get('/sounds/:filename', asyncHandler(async (req, res, next) => {
+const soundsRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+  message: 'Too many requests, please try again later.',
+});
+
+soundsRouter.get('/sounds/:filename', soundsRateLimiter, asyncHandler(async (req, res, next) => {
   const { filename } = req.params;
   console.log(`Requested file: ${filename}`);
 


### PR DESCRIPTION
Potential fix for [https://github.com/OmgRod/CustomDeathSound-Server/security/code-scanning/2](https://github.com/OmgRod/CustomDeathSound-Server/security/code-scanning/2)

To fix the issue, we will add rate limiting to the `soundsRouter` using the `express-rate-limit` package. This package allows us to define a maximum number of requests per time window for the route. The rate limiter will be applied specifically to the `/sounds/:filename` endpoint to ensure that requests to this route are controlled without affecting other parts of the application.

Steps to implement the fix:
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Define a rate limiter configuration with appropriate limits (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter middleware to the `/sounds/:filename` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
